### PR TITLE
Fix environment call

### DIFF
--- a/passhunt.py
+++ b/passhunt.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
+
 '''
 This tool allows you to search for default credentials for routers, network devices, web applications and more. 
 Author: Viral Maniar 


### PR DESCRIPTION
Updated the #! to call python3 via modified environment `env`. This should fix issue #4 in distros where python3 is not the default.